### PR TITLE
fix: brings back smoke integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>22</version>
+      <version>24</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <groupId>io.fabric8</groupId>
@@ -15,7 +15,7 @@
    <properties>
       <failOnMissingWebXml>false</failOnMissingWebXml>
       <!-- Versions -->
-      <arquillian.version>1.1.12.Final</arquillian.version>
+      <arquillian.version>1.1.13.Final</arquillian.version>
       <obsidian.forge.version>${project.version}</obsidian.forge.version>
       <fabric8.version>2.3.3</fabric8.version>
       <fabric8.maven.plugin.version>3.5.22</fabric8.maven.plugin.version>
@@ -279,6 +279,13 @@
          <groupId>org.jboss.forge</groupId>
          <artifactId>forge-service-core</artifactId>
       </dependency>
+     <dependency>
+       <groupId>io.fabric8.forge</groupId>
+       <artifactId>fabric8-generator</artifactId>
+       <version>${fabric8.generator.version}</version>
+       <scope>provided</scope>
+       <classifier>forge-addon</classifier>
+     </dependency>
 
       <dependency>
          <groupId>org.wildfly.swarm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,17 +106,17 @@
    <build>
       <finalName>generator</finalName>
       <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
-            <configuration>
-               <excludes>
-                  <!-- TODO fixme! -->
-                  <exclude>**/ObsidianResourceTest.*</exclude>
-               </excludes>
-            </configuration>
-         </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
          <!--not needed when using fabric8 + Jenkins Pipeines -->
          <!--<plugin>
             <artifactId>maven-release-plugin</artifactId>

--- a/src/test/java/org/obsidiantoaster/generator/rest/Deployments.java
+++ b/src/test/java/org/obsidiantoaster/generator/rest/Deployments.java
@@ -1,0 +1,42 @@
+package org.obsidiantoaster.generator.rest;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class Deployments
+{
+   static Archive<?> createDeployment()
+   {
+      List<String> packageNames = Arrays.asList(ObsidianResource.class.getPackage().getName().split("\\."));
+      String packageName = packageNames.stream()
+            .filter(input -> packageNames.indexOf(input) != packageNames.size() - 1)
+            .collect(Collectors.joining("."));
+      JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class);
+      final File[] artifacts = Maven.resolver()
+            .loadPomFromFile("pom.xml")
+            .importCompileAndRuntimeDependencies()
+            .resolve()
+            .withTransitivity()
+            .asFile();
+      deployment.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+      deployment.merge(ShrinkWrap.create(GenericArchive.class).as(ExplodedImporter.class)
+                  .importDirectory("target/generator/WEB-INF/addons").as(GenericArchive.class),
+            "/WEB-INF/addons", Filters.include(".*"));
+      deployment.addResource(ObsidianResource.class);
+      deployment.addResource(HealthResource.class);
+      deployment.addPackages(true, packageName);
+      deployment.addAsLibraries(artifacts);
+      return deployment;
+   }
+}

--- a/src/test/java/org/obsidiantoaster/generator/rest/HealthResourceIT.java
+++ b/src/test/java/org/obsidiantoaster/generator/rest/HealthResourceIT.java
@@ -15,15 +15,14 @@
  */
 package org.obsidiantoaster.generator.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
-import java.io.StringReader;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -33,53 +32,21 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.io.StringReader;
+import java.net.URI;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.Filters;
-import org.jboss.shrinkwrap.api.GenericArchive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.wildfly.swarm.jaxrs.JAXRSArchive;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-/**
- *
- */
 @RunWith(Arquillian.class)
 public class HealthResourceIT
 {
    private static final String CATAPULT_SERVICE_URL = "CATAPULT_URL";
    
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createDeployment()
    {
-      List<String> packageNames = Arrays.asList(ObsidianResource.class.getPackage().getName().split("\\."));
-      String packageName = packageNames.stream()
-               .filter(input -> packageNames.indexOf(input) != packageNames.size() - 1)
-               .collect(Collectors.joining("."));
-      JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class);
-      final File[] artifacts = Maven.resolver().loadPomFromFile("pom.xml")
-               .resolve("org.jboss.forge:forge-service-core")
-               .withTransitivity().asFile();
-      deployment.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-      deployment.merge(ShrinkWrap.create(GenericArchive.class).as(ExplodedImporter.class)
-               .importDirectory("target/generator/WEB-INF/addons").as(GenericArchive.class),
-               "/WEB-INF/addons", Filters.include(".*"));
-      deployment.addResource(ObsidianResource.class);
-      deployment.addResource(HealthResource.class);
-      deployment.addPackages(true, packageName);
-      deployment.addAsLibraries(artifacts);
-      return deployment;
+      return Deployments.createDeployment();
    }
 
    @ArquillianResource
@@ -96,7 +63,6 @@ public class HealthResourceIT
    }
 
    @Test
-   @RunAsClient
    public void readinessCheck()
    {
       final Response response = readyTarget.request().get();
@@ -111,7 +77,6 @@ public class HealthResourceIT
 
    @Ignore("Until we can run the test against an actual Catapult instance")
    @Test
-   @RunAsClient
    public void catapultReadinessCheck() throws Exception
    {
       String catapultUrlString = System.getProperty(CATAPULT_SERVICE_URL, System.getenv(CATAPULT_SERVICE_URL));

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <engine>
+    <property name="deploymentExportPath">target/deployment</property>
+  </engine>
+
+</arquillian>


### PR DESCRIPTION
This PR enables smoke integration tests which were disabled due to changes in this fork (namely calls to k8s and openshiftio services). Tests are run as a part of the regular build (`mvn clean verify`).

They ensure that we are able to deploy backend with Forge and our addons onto WildFly Swarm without issues. It will be important feedback loop when merging with [upstream project](https://github.com/openshiftio/launchpad-backend). See https://github.com/openshiftio/openshift.io/issues/740 for details.

Two tests are ignored. The one in `ObsidianResourceIT` is due to fixed calls to external services from within `fabric8-generator` addon which require stubbing on HTTP level (and eventually making addon code more flexible by leveraging DI properly so we can stub it differently). This will come later.